### PR TITLE
Bump versions of plugins and dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,15 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 buildscript {
     repositories {
         mavenCentral()
+        mavenLocal()
     }
 }
 
 plugins {
-    id 'com.github.hierynomus.license' version '0.15.0'
+    id 'com.github.hierynomus.license' version '0.16.1'
     id 'com.github.ben-manes.versions' version '0.29.0'
     id 'com.github.spotbugs' version '4.0.6'
+    id 'org.openjfx.javafxplugin' version '0.1.0' apply(false)
 }
 
 rootProject.with { project ->
@@ -50,16 +52,7 @@ rootProject.with { project ->
         buildDate = buildTimeAndDate.format("yyyy-MM-dd")
         buildTime = buildTimeAndDate.format("HH:mm:ss.SSSZ")
 
-        if (JavaVersion.current().isJava11Compatible()) {
-            javadocLinks = ["https://docs.oracle.com/en/java/javase/11/docs/api"]
-        } else if (JavaVersion.current().isJava10Compatible()) {
-            javadocLinks = ["https://docs.oracle.com/javase/10/docs/api"]
-        } else if (JavaVersion.current().isJava9Compatible()) {
-            javadocLinks = ["https://docs.oracle.com/javase/9/docs/api"]
-        } else {
-            javadocLinks = ["http://docs.oracle.com/javase/8/docs/api/",
-                            "http://docs.oracle.com/javase/8/javafx/api/"]
-        }
+        javadocLinks = ["https://docs.oracle.com/en/java/javase/21/docs/api"]
     }
 }
 
@@ -67,7 +60,7 @@ allprojects { project ->
     apply plugin: 'base'
     apply plugin: 'java'
     apply plugin: 'jacoco'
-    apply plugin: 'maven'
+    apply plugin: 'maven-publish'
     apply plugin: 'signing'
     apply from: "${rootDir}/gradle/jacoco.gradle"
     apply from: "${rootDir}/gradle/travis-helpers.gradle"
@@ -77,10 +70,13 @@ allprojects { project ->
     }
 
     repositories {
-        if (project.hasProperty("useMavenLocal")) {
+//        if (project.hasProperty("useMavenLocal")) {
             mavenLocal()
-        }
+//        }
     }
+
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 subprojects { subproject ->
@@ -96,25 +92,23 @@ subprojects { subproject ->
     task sourceJar(type: Jar) {
         group 'Build'
         description 'Assembles a JAR containing the source code.'
-        classifier 'sources'
+        archiveClassifier.set('sources')
         from sourceSets.main.allJava
     }
 
     task javadocJar(type: Jar) {
         group 'Build'
         description 'Assembles a JAR containing the Javadoc.'
-        classifier 'javadoc'
+        archiveClassifier.set('javadoc')
         from javadoc
     }
 
-    jar.finalizedBy createPom
     jar.finalizedBy sourceJar
     jar.finalizedBy javadocJar
 
     artifacts {
         sourceJar
         javadocJar
-        createPom
     }
 
     tasks.withType(JavaCompile) {
@@ -126,7 +120,7 @@ subprojects { subproject ->
     }
 
     test {
-        reports.html.enabled = false
+        reports.html.required = false
         testLogging {
             // set options for log level LIFECYCLE
             events TestLogEvent.STARTED, TestLogEvent.PASSED,
@@ -181,7 +175,8 @@ subprojects { subproject ->
     javadoc {
         enabled = JavaVersion.current().isJava8()
         excludes = ["**/*.html", "META-INF/**"]
-        classpath = configurations.compile + configurations.providedCompile + configurations.compileOnly
+        classpath = configurations.runtimeClasspath + configurations.providedCompile + configurations.compileOnly
+        configurations.compileOnly.setCanBeResolved(true)
         options.use         = true
         options.splitIndex  = true
         options.encoding    = "UTF-8"
@@ -233,29 +228,17 @@ task aggregateJavadoc(type: Javadoc) {
     }
 }
 
-task jacocoMerge(type: JacocoMerge) {
-    group = 'Coverage reports'
-    description = 'Merges individual JaCoCo coverage data in to a single data set.'
-    destinationFile = file("$buildDir/jacoco/jacoco-all.exec")
-    subprojects.each { subproject ->
-        executionData subproject.tasks.withType(Test)
-    }
-    doFirst {
-        executionData = files(executionData.findAll { it.exists() })
-    }
-}
-
 task jacocoRootReport(type: JacocoReport) {
     group = 'Coverage reports'
     description = 'Generates an aggregate JaCoCo coverage report containing the coverage data of each subproject.'
-    dependsOn subprojects.test, jacocoMerge
+    dependsOn subprojects.test
     getAdditionalSourceDirs().setFrom(files(subprojects.sourceSets.main.allSource.srcDirs))
     getSourceDirectories().setFrom(files(subprojects.sourceSets.main.allSource.srcDirs))
     getClassDirectories().setFrom(files(subprojects.sourceSets.main.output))
     getExecutionData().setFrom(files(subprojects.jacocoTestReport.executionData).filter { it.exists() })
 
     reports {
-        html.enabled = true
-        xml.enabled = true
+        html.required = true
+        xml.required = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ evaluationDependsOnChildren()
 
 subprojects { subproject ->
     javadoc {
-        enabled = JavaVersion.current().isJava8()
+        enabled = true
         excludes = ["**/*.html", "META-INF/**"]
         classpath = configurations.runtimeClasspath + configurations.providedCompile + configurations.compileOnly
         configurations.compileOnly.setCanBeResolved(true)

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 buildscript {
     repositories {
         mavenCentral()
-        mavenLocal()
     }
 }
 
@@ -70,9 +69,9 @@ allprojects { project ->
     }
 
     repositories {
-//        if (project.hasProperty("useMavenLocal")) {
+        if (project.hasProperty("useMavenLocal")) {
             mavenLocal()
-//        }
+        }
     }
 
     sourceCompatibility = JavaVersion.VERSION_17

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = org.testfx
-version = 4.0.18
+version = 4.0.19-gluon-SNAPSHOT
 
 projectVendor = The TestFX Contributors
 projectDescription = Simple and clean testing for JavaFX
@@ -8,7 +8,7 @@ projectScm = https://github.com/TestFX/TestFX.git
 projectIssues = https://github.com/TestFX/TestFX/issues
 
 javadocName = TestFX
-javadocFooter = Copyright &copy; 2013-2023 The TestFX Contributors. All rights reserved.
+javadocFooter = Copyright &copy; 2014-2024 The TestFX Contributors. All rights reserved.
 
 sonatypeSnapshotsUrl = https://oss.sonatype.org/content/repositories/snapshots
 sonatypeReleasesUrl = https://oss.sonatype.org/content/repositories/releases

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -30,7 +30,7 @@ checkstyle {
 
 // Decrease verbosity (printing of XSL style sheets, etc.)
 [checkstyleMain, checkstyleTest].each { task ->
-    task.logging.setLevel(LogLevel.LIFECYCLE)
+    task.logging.captureStandardOutput LogLevel.LIFECYCLE
 }
 
 // exclude module info files for Java 9

--- a/gradle/license.gradle
+++ b/gradle/license.gradle
@@ -42,5 +42,5 @@ license {
 
 // Decrease verbosity (printing that the header in each file is OK).
 [licenseMain, licenseTest].each { task ->
-    task.logging.setLevel(LogLevel.LIFECYCLE)
+    task.logging.captureStandardOutput LogLevel.LIFECYCLE
 }

--- a/gradle/publish-pom.gradle
+++ b/gradle/publish-pom.gradle
@@ -15,81 +15,76 @@
  * specific language governing permissions and limitations under the Licence.
  */
 
-task createPom {
-	description 'Generate the artifact pom file for Maven Central'
-	doLast {
-		pom {
-			project {
-				name "${project.pomName}"
-				description "${project.pomDescription}"
-				inceptionYear '2013'
-				url "http://testfx.org/"
+publishing {
+	publications {
+		maven(MavenPublication) {
+			from components.java
+			afterEvaluate {
+				artifact sourceJar
+				artifact javadocJar
+			}
+			description 'Generate the artifact pom file for Maven Central'
+			pom {
+				name = "${project.name}"
+				description = "${project.description}"
+				inceptionYear = '2013'
+				url = "http://testfx.org/"
 
 				licenses {
-					license([:]) {
-						name "European Union Public Licence, Version 1.1"
-						url "http://ec.europa.eu/idabc/eupl.html"
-						distribution "repo"
+					license {
+						name = "European Union Public Licence, Version 1.1"
+						url = "http://ec.europa.eu/idabc/eupl.html"
+						distribution = "repo"
 					}
 				}
 
 				scm {
-					url "https://github.com/TestFX/TestFX"
+					url = "https://github.com/TestFX/TestFX"
 				}
 
 				developers {
 					developer {
-						id "mvsoder"
-						name "Mark Soderquist"
-						url "https://github.com/mvsoder"
-						timezone "-7"
-						roles {
-							role "developer"
-						}
+						id = "mvsoder"
+						name = "Mark Soderquist"
+						url = "https://github.com/mvsoder"
+						timezone = "-7"
+						roles = ["developer"]
 					}
 
 					developer {
-						id "svenruppert"
-						name "Sven Ruppert"
-						url "https://github.com/svenruppert"
-						timezone "+1"
-						roles {
-							role "developer"
-						}
+						id = "svenruppert"
+						name = "Sven Ruppert"
+						url = "https://github.com/svenruppert"
+						timezone = "+1"
+						roles = ["developer"]
 					}
 
 					developer {
-						id "minisu"
-						name "Henrik Olsson"
-						url "https://github.com/minisu"
-						timezone "+1"
-						roles {
-							role "former developer"
-						}
+						id = "minisu"
+						name = "Henrik Olsson"
+						url = "https://github.com/minisu"
+						timezone = "+1"
+						roles = ["former developer"]
 					}
 
 					developer {
-						id "dainnilsson"
-						name "Dain Nilsson"
-						url "https://github.com/dainnilsson"
-						timezone "+1"
-						roles {
-							role "project founder"
-							role "former developer"
-						}
+						id = "dainnilsson"
+						name = "Dain Nilsson"
+						url = "https://github.com/dainnilsson"
+						timezone = "+1"
+						roles = ["project founder",  "former developer"]
 					}
 
 					developer {
-						id "hastebrot"
-						name "Benjamin Gudehus"
-						url "https://github.com/hastebrot"
-						timezone "+1"
-						roles {
-							role "project maintainer"
-						}
+						id = "hastebrot"
+						name = "Benjamin Gudehus"
+						url = " https://github.com/hastebrot"
+						timezone = "+1"
+						roles = ["project maintainer"]
 					}
 				}
 			}
-		}.writeTo("$buildDir/libs/${project.name}-${project.version}.pom")
+		}
+				//.writeTo("$buildDir/libs/${project.name}-${project.version}.pom")
 	}
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/testfx-core/src/main/java/module-info.java
+++ b/subprojects/testfx-core/src/main/java/module-info.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2014 SmartBear Software
+ * Copyright 2014-2024 The TestFX Contributors
+ *
+ * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
+ * European Commission - subsequent versions of the EUPL (the "Licence"); You may
+ * not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * http://ec.europa.eu/idabc/eupl.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+ * specific language governing permissions and limitations under the Licence.
+ */
+module org.testfx {
+    requires static javafx.controls;
+    requires static javafx.swing;
+    requires static javafx.fxml;
+    
+    requires static org.hamcrest;
+    requires static org.assertj.core;
+    requires static osgi.core;
+
+    exports org.testfx.api;
+    exports org.testfx.assertions.api;
+    exports org.testfx.matcher.base;
+    exports org.testfx.matcher.control;
+    exports org.testfx.osgi;
+    exports org.testfx.robot;
+    exports org.testfx.service.adapter;
+    exports org.testfx.service.finder;
+    exports org.testfx.service.locator;
+    exports org.testfx.service.query;
+    exports org.testfx.service.support;
+    exports org.testfx.toolkit;
+    exports org.testfx.util;
+}

--- a/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextAssertTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/assertions/api/TextAssertTest.java
@@ -123,12 +123,14 @@ public class TextAssertTest extends FxRobot {
     @Test
     public void hasFont_fails() {
         assumeThat("skipping: no testable fonts installed on system", fontFamily, is(notNullValue()));
-        assertThatThrownBy(() -> assertThat(quuxText).hasFont(Font.font(fontFamily, 14)))
+        Font font = Font.font(fontFamily, 14);
+        String fontName = font.getName();
+        assertThatThrownBy(() -> assertThat(quuxText).hasFont(font))
                 .isExactlyInstanceOf(AssertionError.class)
                 .hasMessage(String.format("Expected: Text has font " +
-                        "\"%1$s\" with family (\"%1$s\") and size (%2$.1f)\n     " +
+                        "\"%1$s\" with family (\"%2$s\") and size (%3$.1f)\n     " +
                         "but: was Text with font: " +
-                        "\"%1$s\" with family (\"%1$s\") and size (%3$.1f)", fontFamily, 14.0, 16.0));
+                        "\"%1$s\" with family (\"%2$s\") and size (%4$.1f)", fontName, fontFamily, 14.0, 16.0));
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextMatchersTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/matcher/control/TextMatchersTest.java
@@ -102,12 +102,14 @@ public class TextMatchersTest extends FxRobot {
     @Test
     public void hasFont_fails() {
         assumeThat("skipping: no testable fonts installed on system", fontFamily, is(notNullValue()));
-        assertThatThrownBy(() -> assertThat(quuxText, TextMatchers.hasFont(Font.font(fontFamily, 14))))
+        Font font = Font.font(fontFamily, 14);
+        String fontName = font.getName();
+        assertThatThrownBy(() -> assertThat(quuxText, TextMatchers.hasFont(font)))
                 .isExactlyInstanceOf(AssertionError.class)
                 .hasMessage(String.format("\nExpected: Text has font " +
-                        "\"%1$s\" with family (\"%1$s\") and size (%2$.1f)\n     " +
+                        "\"%1$s\" with family (\"%2$s\") and size (%3$.1f)\n     " +
                         "but: was Text with font: " +
-                        "\"%1$s\" with family (\"%1$s\") and size (%3$.1f)", fontFamily, 14.0, 16.0));
+                        "\"%1$s\" with family (\"%2$s\") and size (%4$.1f)", fontName, fontFamily, 14.0, 16.0));
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ClickRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ClickRobotImplTest.java
@@ -34,8 +34,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class ClickRobotImplTest {
 
@@ -64,7 +64,7 @@ public class ClickRobotImplTest {
         verify(mouseRobot, times(1)).pressNoWait(eq(MouseButton.PRIMARY));
         verify(mouseRobot, times(1)).release(eq(MouseButton.PRIMARY));
         verifyNoMoreInteractions(mouseRobot);
-        verifyZeroInteractions(moveRobot, sleepRobot);
+        verifyNoInteractions(moveRobot, sleepRobot);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class ClickRobotImplTest {
             eq(MouseButton.PRIMARY), eq(MouseButton.SECONDARY)
         );
         verifyNoMoreInteractions(mouseRobot);
-        verifyZeroInteractions(moveRobot, sleepRobot);
+        verifyNoInteractions(moveRobot, sleepRobot);
     }
 
     @Test
@@ -96,7 +96,7 @@ public class ClickRobotImplTest {
         verify(mouseRobot, times(1)).pressNoWait(eq(MouseButton.PRIMARY));
         verify(mouseRobot, times(1)).release(eq(MouseButton.PRIMARY));
         verifyNoMoreInteractions(moveRobot, mouseRobot);
-        verifyZeroInteractions(sleepRobot);
+        verifyNoInteractions(sleepRobot);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class ClickRobotImplTest {
         verify(mouseRobot, times(2)).release(eq(MouseButton.PRIMARY));
         verify(sleepRobot, times(1)).sleep(anyLong());
         verifyNoMoreInteractions(mouseRobot, sleepRobot);
-        verifyZeroInteractions(moveRobot);
+        verifyNoInteractions(moveRobot);
     }
 
     @Test
@@ -126,7 +126,7 @@ public class ClickRobotImplTest {
         );
         verify(sleepRobot, times(1)).sleep(anyLong());
         verifyNoMoreInteractions(mouseRobot, sleepRobot);
-        verifyZeroInteractions(moveRobot);
+        verifyNoInteractions(moveRobot);
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/DragRobotImplTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/DragRobotImplTest.java
@@ -32,8 +32,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class DragRobotImplTest {
 
@@ -59,7 +59,7 @@ public class DragRobotImplTest {
         // then:
         verify(mouseRobot, times(1)).press(eq(MouseButton.PRIMARY));
         verifyNoMoreInteractions(mouseRobot);
-        verifyZeroInteractions(moveRobot);
+        verifyNoInteractions(moveRobot);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class DragRobotImplTest {
         // then:
         verify(mouseRobot, times(1)).release();
         verifyNoMoreInteractions(mouseRobot);
-        verifyZeroInteractions(moveRobot);
+        verifyNoInteractions(moveRobot);
     }
 
     @Test

--- a/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
+++ b/subprojects/testfx-core/src/test/java/org/testfx/robot/impl/ShortcutKeyTest.java
@@ -17,6 +17,7 @@
 package org.testfx.robot.impl;
 
 import java.util.concurrent.TimeoutException;
+import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
@@ -156,7 +157,8 @@ public class ShortcutKeyTest extends FxRobot {
         robotContext().getTypeRobot().push(new KeyCodeCombination(KeyCode.A, KeyCombination.SHORTCUT_DOWN));
         robotContext().getTypeRobot().push(new KeyCodeCombination(KeyCode.C, KeyCombination.SHORTCUT_DOWN));
         clickOn(field2, MouseButton.PRIMARY);
-        field2.requestFocus();
+        Platform.runLater(() -> field2.requestFocus());
+        WaitForAsyncUtils.waitForFxEvents();
         robotContext().getTypeRobot().push(new KeyCodeCombination(KeyCode.V, KeyCombination.SHORTCUT_DOWN));
 
         // then:

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -15,191 +15,98 @@
  * specific language governing permissions and limitations under the Licence.
  */
 apply plugin: 'java-library'
+apply plugin: 'org.openjfx.javafxplugin'
 
 ext.pomName = 'TestFX Core'
 ext.pomDescription = 'TestFX core library'
 ext.moduleName = 'org.testfx'
-ext.openjfxVersion = '11'
+ext.openjfxVersion = '23.0.1'
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
-static def getOSName() {
-    final String osName = System.getProperty("os.name").toLowerCase()
-    if (osName.contains("linux")) {
-        return ("linux")
-    } else if (osName.contains("mac os x") || osName.contains("darwin") || osName.contains("osx")) {
-        return ("mac")
-    } else if (osName.contains("windows")) {
-        return ("win")
-    }
-    return ""
+javafx {
+    version = openjfxVersion
+    modules = [ 'javafx.controls', 'javafx.swing', 'javafx.fxml' ]
 }
 
-ext.platform = getOSName()
+dependencies {
+    implementation group: 'org.hamcrest', name: 'hamcrest', version: '3.0'
+    implementation "org.assertj:assertj-core:3.26.3"
+    testImplementation "org.assertj:assertj-core:3.26.3"
+    implementation 'org.osgi:osgi.core:8.0.0'
 
-// This insanity should be removed when JUnit 4 uses hamcrest 2.1.
-// See: https://github.com/junit-team/junit4/pull/1608
-configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails dep ->
-        if (dep.requested.group == 'org.hamcrest') {
-            switch (dep.requested.name) {
-                case 'java-hamcrest':
-                    dep.useTarget("org.hamcrest:hamcrest:${dep.target.version}")
-                    dep.because("2.0.0.0 shouldn't have been published")
-                    break
-                case 'hamcrest-core':
-                    dep.useTarget("org.hamcrest:hamcrest:${dep.target.version}")
-                    dep.because("hamcrest-core doesn't contain anything")
-                    break
-                case 'hamcrest-library':
-                    dep.useTarget("org.hamcrest:hamcrest:${dep.target.version}")
-                    dep.because("hamcrest-library doesn't contain anything")
-                    break
-            }
-        }
+    testImplementation ("junit:junit:4.13.2") {
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
-}
+    // Empty shim JAR for JUnit4.
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: '3.0'
 
-afterEvaluate {
-    dependencies {
-        if (JavaVersion.current().isJava10Compatible()) {
-            // In case we are on an Oracle JDK with JavaFX builtin, these will be ignored.
-            implementation "org.openjfx:javafx-base:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-controls:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-graphics:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-swing:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-fxml:${openjfxVersion}:${platform}"
-        }
+    testImplementation "org.mockito:mockito-core:5.14.2"
 
-        implementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
-        implementation "org.assertj:assertj-core:3.13.2"
-        testImplementation "org.assertj:assertj-core:3.13.2"
-        implementation 'org.osgi:org.osgi.core:6.0.0'
-
-        testImplementation ("junit:junit:4.13-beta-3") {
-            exclude group: 'org.hamcrest', module: 'hamcrest-core'
-        }
-        // Empty shim JAR for JUnit4.
-        testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: '2.1'
-
-        testImplementation "org.mockito:mockito-core:3.0.0"
-
-        if (JavaVersion.current().isJava12Compatible()) {
-            testCompile 'org.testfx:openjfx-monocle:jdk-12.0.1+2'
-        } else if (JavaVersion.current().isJava11Compatible()) {
-            testCompile "org.testfx:openjfx-monocle:jdk-11+26"
-        } else if (JavaVersion.current().isJava10Compatible() &&
-                System.getProperty("java.vm.name").toLowerCase().contains("openjdk")) {
-            testCompile "org.testfx:openjfx-monocle:jdk-11+26"
-        } else if (JavaVersion.current().isJava9Compatible()) {
-            testCompile "org.testfx:openjfx-monocle:jdk-9+181"
-        } else {
-            testCompile "org.testfx:openjfx-monocle:8u76-b04"
-        }
-    }
+    testImplementation 'org.testfx:openjfx-monocle:jdk-12.0.1+2'
 
     configurations {
         apiElements {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
-    }
-
-    if (JavaVersion.current().isJava9Compatible()) {
-        task compileModuleInfoJava(type: JavaCompile) {
-            dependsOn 'compileJava'
-            doFirst {
-                options.compilerArgs = [
-                        '--module-path', compileJava.classpath.asPath,
-                ]
-            }
-            options.encoding = 'UTF-8'
-            classpath = files()
-            source = sourceSets.main.allJava
-            sourceCompatibility = JavaVersion.VERSION_1_9
-            targetCompatibility = JavaVersion.VERSION_1_9
-            destinationDir = compileJava.destinationDir
-        }
-        classes.dependsOn compileModuleInfoJava
-        def dependents = configurations.api.dependencies + configurations.implementation.dependencies
-        def dependentProjects = dependents.findAll { it instanceof ProjectDependency }
-        dependentProjects.each { dependency ->
-            compileModuleInfoJava.dependsOn ":${dependency.name}:compileModuleInfoJava"
-        }
-    }
-
-    javadoc {
-        source = sourceSets.main.allJava
-        //dependsOn compileModuleInfoJava
-        if (JavaVersion.current().isJava9Compatible()) {
-            options.addBooleanOption('html5', true)
-
-            inputs.property("moduleName", moduleName)
-
-            doFirst {
-                options.addStringOption('-module-path', classpath.asPath)
-                options.addStringOption('-add-reads', "$moduleName=org.assertj.core")
-                options.addMultilineStringsOption('-add-modules').setValue([
-                        'javafx.graphics', 'javafx.controls', 'javafx.swing', 'org.hamcrest', 'org.assertj.core'])
-                options.addMultilineStringsOption('-add-exports').setValue([
-                        'javafx.graphics/com.sun.javafx.application=org.testfx',
-                        'javafx.graphics/com.sun.glass.ui=org.testfx'])
-            }
-        }
-    }
-
-    test {
-        if (JavaVersion.current().isJava9Compatible()) {
-            inputs.property("moduleName", moduleName)
-            doFirst {
-                jvmArgs = [
-                        '--module-path', classpath.asPath,
-                        '--add-modules', 'ALL-MODULE-PATH',
-                        '--add-exports', 'org.testfx/org.testfx.service.locator.impl=junit',
-                        '--add-exports', 'org.testfx/org.testfx.service.query.impl=junit',
-                        '--add-exports', 'org.testfx/org.testfx.service.finder.impl=junit',
-                        '--add-exports', 'org.testfx/org.testfx.service.adapter.impl=junit',
-                        '--add-exports', 'org.testfx/org.testfx.service.support.impl=junit',
-                        '--add-exports', 'org.testfx/org.testfx.robot.impl=junit',
-                        '--add-exports', 'org.testfx/org.testfx.toolkit.impl=junit',
-                        '--add-exports', 'org.testfx/org.testfx.cases=junit',
-                        '--add-exports', 'org.testfx/org.testfx.cases.acceptance=junit',
-                        '--add-exports', 'org.testfx/org.testfx.cases.integration=junit',
-                        '--add-exports', 'org.testfx/org.testfx.cases.issue=junit',
-                        '--add-reads', "$moduleName=junit",
-                        '--add-reads', "$moduleName=javafx.fxml",
-                        '--add-opens', "$moduleName/org.testfx.service.query.impl=org.testfx",
-                        '--add-opens', "javafx.graphics/com.sun.glass.ui=$moduleName",
-                        '--add-exports', "javafx.graphics/com.sun.glass.ui=$moduleName",
-                        '--add-exports', "javafx.graphics/com.sun.javafx.application=$moduleName",
-                        '--add-exports', 'javafx.graphics/com.sun.glass.ui=org.testfx.monocle',
-                        '--add-exports', 'javafx.graphics/com.sun.javafx.application=org.testfx.monocle',
-                        '--add-exports', 'javafx.graphics/com.sun.glass.ui.delegate=org.testfx.monocle',
-                        '--patch-module', "$moduleName=" + files(sourceSets.test.java.outputDir, sourceSets.test.resources.srcDirs).asPath,
-                ]
-                classpath = files()
-            }
-        }
-    }
-
-    jar {
-        inputs.property("moduleName", moduleName)
-
-        manifest {
-            attributes(
-                'Automatic-Module-Name': moduleName
-            )
-        }
-        // FIXME: This makes a type of fat/uber JAR that contains all of our dependencies!
-        /*
-        bnd (
-            'Export-Package': '*',
-            'Bundle-Version': "${System.env.JITPACK == 'true' ? '0.0.1' : project.version}",
-            'Bundle-Activator': 'org.testfx.osgi.Activator',
-            'Require-Capability': 'org.testfx.osgi.versionadapter'
-        )
-         */
     }
 }
+
+//    javadoc {
+//        source = sourceSets.main.allJava
+//        //dependsOn compileModuleInfoJava
+//        if (JavaVersion.current().isJava9Compatible()) {
+//            options.addBooleanOption('html5', true)
+//
+//            inputs.property("moduleName", moduleName)
+//
+//            doFirst {
+//                options.addStringOption('-module-path', classpath.asPath)
+//                options.addStringOption('-add-reads', "$moduleName=org.assertj.core")
+//                options.addMultilineStringsOption('-add-modules').setValue([
+//                        'javafx.graphics', 'javafx.controls', 'javafx.swing', 'org.hamcrest', 'org.assertj.core'])
+//                options.addMultilineStringsOption('-add-exports').setValue([
+//                        'javafx.graphics/com.sun.javafx.application=org.testfx',
+//                        'javafx.graphics/com.sun.glass.ui=org.testfx'])
+//            }
+//        }
+//    }
+
+//    test {
+//        if (JavaVersion.current().isJava9Compatible()) {
+//            inputs.property("moduleName", moduleName)
+//            doFirst {
+//                jvmArgs = [
+//                        '--module-path', classpath.asPath,
+//                        '--add-modules', 'ALL-MODULE-PATH',
+//                        '--add-exports', 'org.testfx/org.testfx.service.locator.impl=junit',
+//                        '--add-exports', 'org.testfx/org.testfx.service.query.impl=junit',
+//                        '--add-exports', 'org.testfx/org.testfx.service.finder.impl=junit',
+//                        '--add-exports', 'org.testfx/org.testfx.service.adapter.impl=junit',
+//                        '--add-exports', 'org.testfx/org.testfx.service.support.impl=junit',
+//                        '--add-exports', 'org.testfx/org.testfx.robot.impl=junit',
+//                        '--add-exports', 'org.testfx/org.testfx.toolkit.impl=junit',
+//                        '--add-exports', 'org.testfx/org.testfx.cases=junit',
+//                        '--add-exports', 'org.testfx/org.testfx.cases.acceptance=junit',
+//                        '--add-exports', 'org.testfx/org.testfx.cases.integration=junit',
+//                        '--add-exports', 'org.testfx/org.testfx.cases.issue=junit',
+//                        '--add-reads', "$moduleName=junit",
+//                        '--add-reads', "$moduleName=javafx.fxml",
+//                        '--add-opens', "$moduleName/org.testfx.service.query.impl=org.testfx",
+//                        '--add-opens', "javafx.graphics/com.sun.glass.ui=$moduleName",
+//                        '--add-exports', "javafx.graphics/com.sun.glass.ui=$moduleName",
+//                        '--add-exports', "javafx.graphics/com.sun.javafx.application=$moduleName",
+//                        '--add-exports', 'javafx.graphics/com.sun.glass.ui=org.testfx.monocle',
+//                        '--add-exports', 'javafx.graphics/com.sun.javafx.application=org.testfx.monocle',
+//                        '--add-exports', 'javafx.graphics/com.sun.glass.ui.delegate=org.testfx.monocle',
+//                        '--patch-module', "$moduleName=" + files(sourceSets.test.java.destinationDirectory.asFile.get(), sourceSets.test.resources.srcDirs).asPath,
+//                ]
+//                classpath = files()
+//            }
+//        }
+//    }
+

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -24,7 +24,6 @@ ext.openjfxVersion = '23.0.1'
 
 repositories {
     mavenCentral()
-    mavenLocal()
 }
 
 javafx {

--- a/subprojects/testfx-core/testfx-core.gradle
+++ b/subprojects/testfx-core/testfx-core.gradle
@@ -55,57 +55,8 @@ dependencies {
     }
 }
 
-//    javadoc {
-//        source = sourceSets.main.allJava
-//        //dependsOn compileModuleInfoJava
-//        if (JavaVersion.current().isJava9Compatible()) {
-//            options.addBooleanOption('html5', true)
-//
-//            inputs.property("moduleName", moduleName)
-//
-//            doFirst {
-//                options.addStringOption('-module-path', classpath.asPath)
-//                options.addStringOption('-add-reads', "$moduleName=org.assertj.core")
-//                options.addMultilineStringsOption('-add-modules').setValue([
-//                        'javafx.graphics', 'javafx.controls', 'javafx.swing', 'org.hamcrest', 'org.assertj.core'])
-//                options.addMultilineStringsOption('-add-exports').setValue([
-//                        'javafx.graphics/com.sun.javafx.application=org.testfx',
-//                        'javafx.graphics/com.sun.glass.ui=org.testfx'])
-//            }
-//        }
-//    }
-
-//    test {
-//        if (JavaVersion.current().isJava9Compatible()) {
-//            inputs.property("moduleName", moduleName)
-//            doFirst {
-//                jvmArgs = [
-//                        '--module-path', classpath.asPath,
-//                        '--add-modules', 'ALL-MODULE-PATH',
-//                        '--add-exports', 'org.testfx/org.testfx.service.locator.impl=junit',
-//                        '--add-exports', 'org.testfx/org.testfx.service.query.impl=junit',
-//                        '--add-exports', 'org.testfx/org.testfx.service.finder.impl=junit',
-//                        '--add-exports', 'org.testfx/org.testfx.service.adapter.impl=junit',
-//                        '--add-exports', 'org.testfx/org.testfx.service.support.impl=junit',
-//                        '--add-exports', 'org.testfx/org.testfx.robot.impl=junit',
-//                        '--add-exports', 'org.testfx/org.testfx.toolkit.impl=junit',
-//                        '--add-exports', 'org.testfx/org.testfx.cases=junit',
-//                        '--add-exports', 'org.testfx/org.testfx.cases.acceptance=junit',
-//                        '--add-exports', 'org.testfx/org.testfx.cases.integration=junit',
-//                        '--add-exports', 'org.testfx/org.testfx.cases.issue=junit',
-//                        '--add-reads', "$moduleName=junit",
-//                        '--add-reads', "$moduleName=javafx.fxml",
-//                        '--add-opens', "$moduleName/org.testfx.service.query.impl=org.testfx",
-//                        '--add-opens', "javafx.graphics/com.sun.glass.ui=$moduleName",
-//                        '--add-exports', "javafx.graphics/com.sun.glass.ui=$moduleName",
-//                        '--add-exports', "javafx.graphics/com.sun.javafx.application=$moduleName",
-//                        '--add-exports', 'javafx.graphics/com.sun.glass.ui=org.testfx.monocle',
-//                        '--add-exports', 'javafx.graphics/com.sun.javafx.application=org.testfx.monocle',
-//                        '--add-exports', 'javafx.graphics/com.sun.glass.ui.delegate=org.testfx.monocle',
-//                        '--patch-module', "$moduleName=" + files(sourceSets.test.java.destinationDirectory.asFile.get(), sourceSets.test.resources.srcDirs).asPath,
-//                ]
-//                classpath = files()
-//            }
-//        }
-//    }
+javadoc {
+    source = sourceSets.main.allJava
+    options.addBooleanOption('html5', true)
+}
 

--- a/subprojects/testfx-junit/src/main/java/module-info.java
+++ b/subprojects/testfx-junit/src/main/java/module-info.java
@@ -1,34 +1,25 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2024 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
  * not use this work except in compliance with the Licence.
  *
  * You may obtain a copy of the Licence at:
- * http://ec.europa.eu/idabc/eupl
+ * http://ec.europa.eu/idabc/eupl.html
  *
  * Unless required by applicable law or agreed to in writing, software distributed
  * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+module org.testfx.junit {
+    requires javafx.graphics;
+    requires org.testfx;
 
-// JaCoCo: Java Code Coverage Library
-// http://www.eclemma.org/jacoco/
+    requires org.assertj.core;
+    requires junit;
 
-apply plugin: "jacoco"
-
-jacoco {
-    toolVersion = "0.8.11"
-}
-
-jacocoTestReport {
-    group = 'Coverage reports'
-    description = 'Generates a test coverage report for a project'
-    reports {
-        html.required = true
-        xml.required = true
-    }
+    exports org.testfx.framework.junit;
 }

--- a/subprojects/testfx-junit/testfx-junit.gradle
+++ b/subprojects/testfx-junit/testfx-junit.gradle
@@ -24,7 +24,6 @@ ext.openjfxVersion = '23.0.1'
 
 repositories {
     mavenCentral()
-    mavenLocal()
 }
 
 javafx {

--- a/subprojects/testfx-junit/testfx-junit.gradle
+++ b/subprojects/testfx-junit/testfx-junit.gradle
@@ -15,160 +15,62 @@
  * specific language governing permissions and limitations under the Licence.
  */
 apply plugin: 'java-library'
+apply plugin: 'org.openjfx.javafxplugin'
 
 ext.pomName = 'TestFX JUnit'
 ext.pomDescription = 'TestFX JUnit library'
 ext.moduleName = 'org.testfx.junit'
-ext.openjfxVersion = '11'
-
-static def getOSName() {
-    final String osName = System.getProperty("os.name").toLowerCase()
-    if (osName.contains("linux")) {
-        return ("linux")
-    } else if (osName.contains("mac os x") || osName.contains("darwin") || osName.contains("osx")) {
-        return ("mac")
-    } else if (osName.contains("windows")) {
-        return ("win")
-    }
-    return ""
-}
-
-ext.platform = getOSName()
+ext.openjfxVersion = '23.0.1'
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
-// This insanity should be removed when JUnit 4 uses hamcrest 2.1.
-// See: https://github.com/junit-team/junit4/pull/1608
-configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails dep ->
-        if (dep.requested.group == 'org.hamcrest') {
-            switch (dep.requested.name) {
-                case 'java-hamcrest':
-                    dep.useTarget("org.hamcrest:hamcrest:${dep.target.version}")
-                    dep.because("2.0.0.0 shouldn't have been published")
-                    break
-                case 'hamcrest-core':
-                    dep.useTarget("org.hamcrest:hamcrest:${dep.target.version}")
-                    dep.because("hamcrest-core doesn't contain anything")
-                    break
-                case 'hamcrest-library':
-                    dep.useTarget("org.hamcrest:hamcrest:${dep.target.version}")
-                    dep.because("hamcrest-library doesn't contain anything")
-                    break
-            }
-        }
-    }
+javafx {
+    version = openjfxVersion
+    modules = [ 'javafx.controls', 'javafx.swing', 'javafx.fxml' ]
 }
 
 afterEvaluate {
     dependencies {
-        if (JavaVersion.current().isJava10Compatible()) {
-            // In case we are on an Oracle JDK with JavaFX builtin, these will be ignored.
-            implementation "org.openjfx:javafx-base:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-graphics:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-controls:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-swing:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-fxml:${openjfxVersion}:${platform}"
-        }
+        api project(":testfx-core")
 
-        compile project(":testfx-core")
-
-        compile ("junit:junit:4.13-beta-3") {
+        api("junit:junit:4.13.2") {
             exclude group: 'org.hamcrest', module: 'hamcrest-core'
             exclude group: 'org.hamcrest', module: 'hamcrest-library'
         }
-        compile group: 'org.hamcrest', name: 'hamcrest-core', version: '2.1'
-        testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '2.1'
-        testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-        implementation "org.assertj:assertj-core:3.13.2"
-        //testCompile "org.assertj:assertj-core:3.13.2"
+        api 'org.hamcrest:hamcrest:3.0'
+        testImplementation 'org.hamcrest:hamcrest:3.0'
+        implementation "org.assertj:assertj-core:3.26.3"
 
-        if (JavaVersion.current().isJava12Compatible()) {
-            testCompile 'org.testfx:openjfx-monocle:jdk-12.0.1+2'
-        } else if (JavaVersion.current().isJava11Compatible()) {
-            testCompile "org.testfx:openjfx-monocle:jdk-11+26"
-        } else if (JavaVersion.current().isJava10Compatible() &&
-                System.getProperty("java.vm.name").toLowerCase().contains("openjdk")) {
-            testCompile "org.testfx:openjfx-monocle:jdk-11+26"
-        } else if (JavaVersion.current().isJava9Compatible()) {
-            testCompile "org.testfx:openjfx-monocle:jdk-9+181"
-        } else {
-            testCompile "org.testfx:openjfx-monocle:8u76-b04"
-        }
+        testImplementation 'org.testfx:openjfx-monocle:jdk-12.0.1+2'
     }
 
     configurations {
         apiElements {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
     }
 
-    if (JavaVersion.current().isJava9Compatible()) {
-        task compileModuleInfoJava(type: JavaCompile) {
-            dependsOn 'compileJava'
-            doFirst {
-                options.compilerArgs = [
-                        '--module-path', compileJava.classpath.asPath,
-                ]
-            }
-            options.encoding = 'UTF-8'
-            classpath = files()
-            source = sourceSets.main.allJava
-            sourceCompatibility = JavaVersion.VERSION_1_9
-            targetCompatibility = JavaVersion.VERSION_1_9
-            destinationDir = compileJava.destinationDir
-        }
-        classes.dependsOn compileModuleInfoJava
-        def dependents = configurations.api.dependencies + configurations.implementation.dependencies
-        def dependentProjects = dependents.findAll { it instanceof ProjectDependency }
-        dependentProjects.each { dependency ->
-            compileModuleInfoJava.dependsOn ":${dependency.name}:compileModuleInfoJava"
-        }
-    }
+//    javadoc {
+//        source = sourceSets.main.allJava
+//        //dependsOn compileModuleInfoJava
+//        if (JavaVersion.current().isJava9Compatible()) {
+//            options.addBooleanOption('html5', true)
+//
+//            inputs.property("moduleName", moduleName)
+//
+//            doFirst {
+//                options.addStringOption('-module-path', classpath.asPath)
+//                options.addMultilineStringsOption('-add-modules').setValue([
+//                        'javafx.graphics', 'javafx.controls', 'javafx.swing', 'org.hamcrest', 'org.testfx'])
+//                options.addMultilineStringsOption('-add-exports').setValue([
+//                        'javafx.graphics/com.sun.javafx.application=org.testfx',
+//                        'javafx.graphics/com.sun.glass.ui=org.testfx'])
+//            }
+//        }
+//    }
 
-    javadoc {
-        source = sourceSets.main.allJava
-        //dependsOn compileModuleInfoJava
-        if (JavaVersion.current().isJava9Compatible()) {
-            options.addBooleanOption('html5', true)
-
-            inputs.property("moduleName", moduleName)
-
-            doFirst {
-                options.addStringOption('-module-path', classpath.asPath)
-                options.addMultilineStringsOption('-add-modules').setValue([
-                        'javafx.graphics', 'javafx.controls', 'javafx.swing', 'org.hamcrest', 'org.testfx'])
-                options.addMultilineStringsOption('-add-exports').setValue([
-                        'javafx.graphics/com.sun.javafx.application=org.testfx',
-                        'javafx.graphics/com.sun.glass.ui=org.testfx'])
-            }
-        }
-    }
-
-    test {
-        if (JavaVersion.current().isJava9Compatible()) {
-            inputs.property("moduleName", moduleName)
-            doFirst {
-                jvmArgs = [
-                        '--module-path', classpath.asPath,
-                        '--add-reads', "$moduleName=junit",
-                        '--add-reads', "$moduleName=org.assertj.core",
-                        '--patch-module', "$moduleName=" + files(sourceSets.test.java.outputDir).asPath,
-                ]
-            }
-        }
-    }
-
-    jar {
-        inputs.property("moduleName", moduleName)
-
-        manifest {
-            attributes(
-                'Automatic-Module-Name': moduleName
-            )
-        }
-    }
 }

--- a/subprojects/testfx-junit/testfx-junit.gradle
+++ b/subprojects/testfx-junit/testfx-junit.gradle
@@ -53,23 +53,9 @@ afterEvaluate {
         }
     }
 
-//    javadoc {
-//        source = sourceSets.main.allJava
-//        //dependsOn compileModuleInfoJava
-//        if (JavaVersion.current().isJava9Compatible()) {
-//            options.addBooleanOption('html5', true)
-//
-//            inputs.property("moduleName", moduleName)
-//
-//            doFirst {
-//                options.addStringOption('-module-path', classpath.asPath)
-//                options.addMultilineStringsOption('-add-modules').setValue([
-//                        'javafx.graphics', 'javafx.controls', 'javafx.swing', 'org.hamcrest', 'org.testfx'])
-//                options.addMultilineStringsOption('-add-exports').setValue([
-//                        'javafx.graphics/com.sun.javafx.application=org.testfx',
-//                        'javafx.graphics/com.sun.glass.ui=org.testfx'])
-//            }
-//        }
-//    }
+    javadoc {
+        source = sourceSets.main.allJava
+        options.addBooleanOption('html5', true)
+    }
 
 }

--- a/subprojects/testfx-junit5/src/main/java/module-info.java
+++ b/subprojects/testfx-junit5/src/main/java/module-info.java
@@ -20,6 +20,7 @@ module org.testfx.junit.jupiter {
 
     requires org.assertj.core;
     requires org.junit.jupiter.api;
+    requires static transitive org.apiguardian.api;
 
     exports org.testfx.framework.junit5;
     exports org.testfx.framework.junit5.utils;

--- a/subprojects/testfx-junit5/src/main/java/module-info.java
+++ b/subprojects/testfx-junit5/src/main/java/module-info.java
@@ -1,34 +1,26 @@
 /*
  * Copyright 2013-2014 SmartBear Software
- * Copyright 2014-2017 The TestFX Contributors
+ * Copyright 2014-2024 The TestFX Contributors
  *
  * Licensed under the EUPL, Version 1.1 or - as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence"); You may
  * not use this work except in compliance with the Licence.
  *
  * You may obtain a copy of the Licence at:
- * http://ec.europa.eu/idabc/eupl
+ * http://ec.europa.eu/idabc/eupl.html
  *
  * Unless required by applicable law or agreed to in writing, software distributed
  * under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+module org.testfx.junit.jupiter {
+    requires javafx.graphics;
+    requires org.testfx;
 
-// JaCoCo: Java Code Coverage Library
-// http://www.eclemma.org/jacoco/
+    requires org.assertj.core;
+    requires org.junit.jupiter.api;
 
-apply plugin: "jacoco"
-
-jacoco {
-    toolVersion = "0.8.11"
-}
-
-jacocoTestReport {
-    group = 'Coverage reports'
-    description = 'Generates a test coverage report for a project'
-    reports {
-        html.required = true
-        xml.required = true
-    }
+    exports org.testfx.framework.junit5;
+    exports org.testfx.framework.junit5.utils;
 }

--- a/subprojects/testfx-junit5/testfx-junit5.gradle
+++ b/subprojects/testfx-junit5/testfx-junit5.gradle
@@ -24,7 +24,6 @@ ext.openjfxVersion = '23.0.1'
 
 repositories {
     mavenCentral()
-    mavenLocal()
 }
 
 javafx {

--- a/subprojects/testfx-junit5/testfx-junit5.gradle
+++ b/subprojects/testfx-junit5/testfx-junit5.gradle
@@ -35,6 +35,7 @@ afterEvaluate {
     dependencies {
         api project(":testfx-core")
 
+        compileOnly 'org.apiguardian:apiguardian-api:1.1.2'
         compileOnly 'org.junit.jupiter:junit-jupiter-api:5.11.3'
         testCompileOnly 'org.junit.jupiter:junit-jupiter-api:5.11.3'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.3'
@@ -53,24 +54,10 @@ afterEvaluate {
         }
     }
 
-//    javadoc {
-//        source = sourceSets.main.allJava
-//        //dependsOn compileModuleInfoJava
-//        if (JavaVersion.current().isJava9Compatible()) {
-//            options.addBooleanOption('html5', true)
-//
-//            inputs.property("moduleName", moduleName)
-//
-//            doFirst {
-//                options.addStringOption('-module-path', classpath.asPath)
-//                options.addMultilineStringsOption('-add-modules').setValue([
-//                        'javafx.graphics', 'javafx.controls', 'javafx.swing', 'org.hamcrest', 'org.testfx'])
-//                options.addMultilineStringsOption('-add-exports').setValue([
-//                        'javafx.graphics/com.sun.javafx.application=org.testfx',
-//                        'javafx.graphics/com.sun.glass.ui=org.testfx'])
-//            }
-//        }
-//    }
+    javadoc {
+        source = sourceSets.main.allJava
+        options.addBooleanOption('html5', true)
+    }
 
     test {
         useJUnitPlatform()

--- a/subprojects/testfx-junit5/testfx-junit5.gradle
+++ b/subprojects/testfx-junit5/testfx-junit5.gradle
@@ -15,148 +15,66 @@
  * specific language governing permissions and limitations under the Licence.
  */
 apply plugin: 'java-library'
+apply plugin: 'org.openjfx.javafxplugin'
 
 ext.pomName = 'TestFX JUnit5'
 ext.pomDescription = 'TestFX JUnit5 library'
 ext.moduleName = 'org.testfx.junit5'
-ext.openjfxVersion = '11'
-
-static def getOSName() {
-    final String osName = System.getProperty("os.name").toLowerCase()
-    if (osName.contains("linux")) {
-        return ("linux")
-    } else if (osName.contains("mac os x") || osName.contains("darwin") || osName.contains("osx")) {
-        return ("mac")
-    } else if (osName.contains("windows")) {
-        return ("win")
-    }
-    return ""
-}
-
-ext.platform = getOSName()
+ext.openjfxVersion = '23.0.1'
 
 repositories {
     mavenCentral()
+    mavenLocal()
+}
+
+javafx {
+    version = openjfxVersion
+    modules = [ 'javafx.controls', 'javafx.swing', 'javafx.fxml' ]
 }
 
 afterEvaluate {
     dependencies {
-        if (JavaVersion.current().isJava10Compatible()) {
-            // In case we are on an Oracle JDK with JavaFX builtin, these will be ignored.
-            implementation "org.openjfx:javafx-base:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-graphics:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-controls:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-swing:${openjfxVersion}:${platform}"
-            implementation "org.openjfx:javafx-fxml:${openjfxVersion}:${platform}"
-        }
+        api project(":testfx-core")
 
-        compile project(":testfx-core")
+        compileOnly 'org.junit.jupiter:junit-jupiter-api:5.11.3'
+        testCompileOnly 'org.junit.jupiter:junit-jupiter-api:5.11.3'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.3'
+        implementation group: 'org.hamcrest', name: 'hamcrest', version: '3.0'
+        testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '3.0'
+        implementation "org.assertj:assertj-core:3.26.3"
+        testImplementation 'org.awaitility:awaitility:4.2.2'
 
-        compileOnly 'org.junit.jupiter:junit-jupiter-api:5.10.1'
-        testCompileOnly 'org.junit.jupiter:junit-jupiter-api:5.10.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.1'
-        implementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
-        testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
-        implementation "org.assertj:assertj-core:3.13.2"
-        //testImplementation "org.assertj:assertj-core:3.13.2"
-        testImplementation 'org.awaitility:awaitility:4.0.2'
-
-        if (JavaVersion.current().isJava12Compatible()) {
-            testCompile 'org.testfx:openjfx-monocle:jdk-12.0.1+2'
-        } else if (JavaVersion.current().isJava11Compatible()) {
-            testCompile "org.testfx:openjfx-monocle:jdk-11+26"
-        } else if (JavaVersion.current().isJava10Compatible() &&
-                System.getProperty("java.vm.name").toLowerCase().contains("openjdk")) {
-            testCompile "org.testfx:openjfx-monocle:jdk-11+26"
-        } else if (JavaVersion.current().isJava9Compatible()) {
-            testCompile "org.testfx:openjfx-monocle:jdk-9+181"
-        } else {
-            testCompile "org.testfx:openjfx-monocle:8u76-b04"
-        }
+        testImplementation 'org.testfx:openjfx-monocle:jdk-12.0.1+2'
     }
 
     configurations {
         apiElements {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
     }
 
-    if (JavaVersion.current().isJava9Compatible()) {
-        task compileModuleInfoJava(type: JavaCompile) {
-            dependsOn 'compileJava'
-            doFirst {
-                options.compilerArgs = [
-                        '--module-path', compileJava.classpath.asPath,
-                ]
-            }
-            options.encoding = 'UTF-8'
-            classpath = files()
-            source = sourceSets.main.allJava
-            sourceCompatibility = JavaVersion.VERSION_1_9
-            targetCompatibility = JavaVersion.VERSION_1_9
-            destinationDir = compileJava.destinationDir
-        }
-        classes.dependsOn compileModuleInfoJava
-        def dependents = configurations.api.dependencies + configurations.implementation.dependencies
-        def dependentProjects = dependents.findAll { it instanceof ProjectDependency }
-        dependentProjects.each { dependency ->
-            compileModuleInfoJava.dependsOn ":${dependency.name}:compileModuleInfoJava"
-        }
-    }
-
-    javadoc {
-        source = sourceSets.main.allJava
-        //dependsOn compileModuleInfoJava
-        if (JavaVersion.current().isJava9Compatible()) {
-            options.addBooleanOption('html5', true)
-
-            inputs.property("moduleName", moduleName)
-
-            doFirst {
-                options.addStringOption('-module-path', classpath.asPath)
-                options.addMultilineStringsOption('-add-modules').setValue([
-                        'javafx.graphics', 'javafx.controls', 'javafx.swing', 'org.hamcrest', 'org.testfx'])
-                options.addMultilineStringsOption('-add-exports').setValue([
-                        'javafx.graphics/com.sun.javafx.application=org.testfx',
-                        'javafx.graphics/com.sun.glass.ui=org.testfx'])
-            }
-        }
-    }
-
-    compileTestJava {
-        if (JavaVersion.current().isJava9Compatible()) {
-            sourceCompatibility = JavaVersion.VERSION_1_9
-            targetCompatibility = JavaVersion.VERSION_1_9
-            inputs.property("moduleName", moduleName)
-            doFirst {
-                options.compilerArgs = [
-                        '--module-path', classpath.asPath,
-                        '--add-modules', 'org.junit.jupiter.api',
-                        '--add-modules', 'org.hamcrest',
-                        '--add-modules', 'org.assertj.core',
-                        '--add-reads', "$moduleName=org.junit.jupiter.api",
-                        '--add-reads', "$moduleName=javafx.controls",
-                        '--add-reads', "$moduleName=org.hamcrest",
-                        '--add-reads', "$moduleName=org.assertj.core",
-                        '--patch-module', "$moduleName=" + files(sourceSets.test.java.srcDirs).asPath,
-                ]
-                classpath = files()
-            }
-        }
-    }
+//    javadoc {
+//        source = sourceSets.main.allJava
+//        //dependsOn compileModuleInfoJava
+//        if (JavaVersion.current().isJava9Compatible()) {
+//            options.addBooleanOption('html5', true)
+//
+//            inputs.property("moduleName", moduleName)
+//
+//            doFirst {
+//                options.addStringOption('-module-path', classpath.asPath)
+//                options.addMultilineStringsOption('-add-modules').setValue([
+//                        'javafx.graphics', 'javafx.controls', 'javafx.swing', 'org.hamcrest', 'org.testfx'])
+//                options.addMultilineStringsOption('-add-exports').setValue([
+//                        'javafx.graphics/com.sun.javafx.application=org.testfx',
+//                        'javafx.graphics/com.sun.glass.ui=org.testfx'])
+//            }
+//        }
+//    }
 
     test {
         useJUnitPlatform()
     }
 
-    jar {
-        inputs.property("moduleName", moduleName)
-
-        manifest {
-            attributes(
-                'Automatic-Module-Name': moduleName
-            )
-        }
-    }
 }

--- a/subprojects/testfx-spock/testfx-spock.gradle
+++ b/subprojects/testfx-spock/testfx-spock.gradle
@@ -27,7 +27,6 @@ apply plugin: 'groovy'
 
 repositories {
     mavenCentral()
-    mavenLocal()
 }
 
 groovydoc {

--- a/subprojects/testfx-spock/testfx-spock.gradle
+++ b/subprojects/testfx-spock/testfx-spock.gradle
@@ -14,30 +14,20 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
  * specific language governing permissions and limitations under the Licence.
  */
+
+apply plugin: 'org.openjfx.javafxplugin'
+
 ext.pomName = 'TestFX Spock'
 ext.pomDescription = 'TestFX Spock library'
 ext.moduleName = 'org.testfx.spock'
-ext.openjfxVersion = '11'
-
-static def getOSName() {
-    final String osName = System.getProperty("os.name").toLowerCase()
-    if (osName.contains("linux")) {
-        return ("linux")
-    } else if (osName.contains("mac os x") || osName.contains("darwin") || osName.contains("osx")) {
-        return ("mac")
-    } else if (osName.contains("windows")) {
-        return ("win")
-    }
-    return ""
-}
-
-ext.platform = getOSName()
+ext.openjfxVersion = '23.0.1'
 
 apply plugin: 'groovy'
-apply plugin: 'codenarc'
+//apply plugin: 'codenarc'
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 groovydoc {
@@ -45,59 +35,44 @@ groovydoc {
 }
 
 task groovydocJar(type: Jar, dependsOn: groovydoc) {
-    baseName 'testfx-spock'
-    classifier 'groovydoc'
+    archiveBaseName.set('testfx-spock')
+    archiveClassifier.set('groovydoc')
     from groovydoc.destinationDir
 }
 
-codenarc {
-    toolVersion = "1.0"
-    reportFormat = 'console'
-}
+//codenarc {
+//    toolVersion = "1.0"
+//    reportFormat = 'console'
+//}
 
-codenarcMain {
-    configFile = file("${rootDir}/gradle/codenarc/rules.groovy")
-    maxPriority1Violations 0
-    maxPriority2Violations 10
-    maxPriority3Violations 20
-}
-
-codenarcTest {
-    configFile = file("${rootDir}/gradle/codenarc/rules.groovy")
-    maxPriority1Violations 0
-    maxPriority2Violations 10
-    maxPriority3Violations 20
-}
+//codenarcMain {
+//    configFile = file("${rootDir}/gradle/codenarc/rules.groovy")
+//    maxPriority1Violations 0
+//    maxPriority2Violations 10
+//    maxPriority3Violations 20
+//}
+//
+//codenarcTest {
+//    configFile = file("${rootDir}/gradle/codenarc/rules.groovy")
+//    maxPriority1Violations 0
+//    maxPriority2Violations 10
+//    maxPriority3Violations 20
+//}
 
 artifacts {
     archives groovydocJar
 }
 
+javafx {
+    version = openjfxVersion
+    modules = [ 'javafx.controls' ]
+}
+
 dependencies {
-    dependencies {
-        if (JavaVersion.current().isJava10Compatible()) {
-            // In case we are on an Oracle JDK with JavaFX builtin, these will be ignored.
-            compile "org.openjfx:javafx-base:${openjfxVersion}:${platform}"
-            compile "org.openjfx:javafx-graphics:${openjfxVersion}:${platform}"
-            compile "org.openjfx:javafx-controls:${openjfxVersion}:${platform}"
-        }
-    }
+    implementation project(":testfx-core")
 
-    compile project(":testfx-core")
+    compileOnly 'org.spockframework:spock-core:2.4-M4-groovy-4.0'
+    testCompileOnly 'org.spockframework:spock-core:2.4-M4-groovy-4.0'
 
-    compileOnly group: 'org.spockframework', name: 'spock-core', version: '1.3-groovy-2.5'
-    testCompileOnly group: 'org.spockframework', name: 'spock-core', version: '1.3-groovy-2.5'
-
-    if (JavaVersion.current().isJava12Compatible()) {
-        testCompile 'org.testfx:openjfx-monocle:jdk-12.0.1+2'
-    } else if (JavaVersion.current().isJava11Compatible()) {
-        testCompile "org.testfx:openjfx-monocle:jdk-11+26"
-    } else if (JavaVersion.current().isJava10Compatible() &&
-            System.getProperty("java.vm.name").toLowerCase().contains("openjdk")) {
-        testCompile "org.testfx:openjfx-monocle:jdk-11+26"
-    } else if (JavaVersion.current().isJava9Compatible()) {
-        testCompile "org.testfx:openjfx-monocle:jdk-9+181"
-    } else {
-        testCompile "org.testfx:openjfx-monocle:8u76-b04"
-    }
+    testImplementation 'org.testfx:openjfx-monocle:jdk-12.0.1+2'
 }


### PR DESCRIPTION
Use JavaFX plugin, add module descriptors and run with JDK 21 and JavaFX 23.0.1 Fix failing tests

Fixes #1 

This PR can be tested locally just by using JDK 21+ and running

```
sh gradlew clean build
```

Tests will run non-headlessly, that is without headless or monacle platforms, so any interaction with mouse/keyboard must be avoided.